### PR TITLE
[Request] Updated fast forward variables to support more granularity.

### DIFF
--- a/EmuFramework/include/emuframework/EmuApp.hh
+++ b/EmuFramework/include/emuframework/EmuApp.hh
@@ -166,7 +166,7 @@ public:
 	void removeTurboInputEvent(unsigned action);
 	void runTurboInputEvents();
 	void resetInput();
-	void setFastForwardSpeed(int speed);
+	void setFastForwardSpeed(float speed);
 	void saveSessionOptions();
 	void loadSessionOptions();
 	bool hasSavedSessionOptions();

--- a/EmuFramework/include/emuframework/OptionView.hh
+++ b/EmuFramework/include/emuframework/OptionView.hh
@@ -157,8 +157,8 @@ protected:
 	MultiChoiceMenuItem autoSaveState;
 	BoolMenuItem confirmAutoLoadState;
 	BoolMenuItem confirmOverwriteState;
-	static constexpr int MIN_FAST_FORWARD_SPEED = 2;
-	TextMenuItem fastForwardSpeedItem[6];
+	static constexpr int MIN_FAST_FORWARD_SPEED = 1;
+	TextMenuItem fastForwardSpeedItem[8];
 	MultiChoiceMenuItem fastForwardSpeed;
 	IG_UseMemberIf(Config::envIsAndroid, BoolMenuItem, performanceMode);
 	StaticArrayList<MenuItem*, 24> item{};

--- a/EmuFramework/src/EmuApp.cc
+++ b/EmuFramework/src/EmuApp.cc
@@ -156,7 +156,7 @@ EmuApp::EmuApp(ApplicationInitParams initParams, ApplicationContext &ctx):
 	optionAutoSaveState{CFGKEY_AUTO_SAVE_STATE, 1},
 	optionConfirmAutoLoadState{CFGKEY_CONFIRM_AUTO_LOAD_STATE, 1},
 	optionConfirmOverwriteState{CFGKEY_CONFIRM_OVERWRITE_STATE, 1},
-	optionFastForwardSpeed{CFGKEY_FAST_FORWARD_SPEED, 4, false, optionIsValidWithMinMax<2, 7>},
+	optionFastForwardSpeed{CFGKEY_FAST_FORWARD_SPEED, 4, false, optionIsValidWithMinMax<1, 7>},
 	optionSound{CFGKEY_SOUND, OPTION_SOUND_DEFAULT_FLAGS},
 	optionSoundVolume{CFGKEY_SOUND_VOLUME,
 		100, false, optionIsValidWithMinMax<0, 100, uint8_t>},
@@ -1330,7 +1330,7 @@ void EmuApp::resetInput()
 	setFastForwardSpeed(0);
 }
 
-void EmuApp::setFastForwardSpeed(int speed)
+void EmuApp::setFastForwardSpeed(float speed)
 {
 	bool active = speed > 1;
 	system().targetFastForwardSpeed = speed;

--- a/EmuFramework/src/SystemOptionView.cc
+++ b/EmuFramework/src/SystemOptionView.cc
@@ -151,12 +151,14 @@ SystemOptionView::SystemOptionView(ViewAttachParams attach, bool customMenu):
 	},
 	fastForwardSpeedItem
 	{
-		{"2x", &defaultFace(), setFastForwardSpeedDel(), 2},
-		{"3x", &defaultFace(), setFastForwardSpeedDel(), 3},
-		{"4x", &defaultFace(), setFastForwardSpeedDel(), 4},
-		{"5x", &defaultFace(), setFastForwardSpeedDel(), 5},
-		{"6x", &defaultFace(), setFastForwardSpeedDel(), 6},
-		{"7x", &defaultFace(), setFastForwardSpeedDel(), 7},
+		{"1.25x", &defaultFace(), setFastForwardSpeedDel(), 1.25},
+		{"1.5x", &defaultFace(), setFastForwardSpeedDel(), 1.5},
+		{"2x", &defaultFace(), setFastForwardSpeedDel(), 2.0},
+		{"3x", &defaultFace(), setFastForwardSpeedDel(), 3.0},
+		{"4x", &defaultFace(), setFastForwardSpeedDel(), 4.0},
+		{"5x", &defaultFace(), setFastForwardSpeedDel(), 5.0},
+		{"6x", &defaultFace(), setFastForwardSpeedDel(), 6.0},
+		{"7x", &defaultFace(), setFastForwardSpeedDel(), 7.0},
 	},
 	fastForwardSpeed
 	{


### PR DESCRIPTION
These coding changes were done with the intent of adding two more granular fast forward options to the emulator framework (1.25x and 1.5x).