### PR TITLE
Upgrade Android NDK from r26b to r26c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,9 @@ jobs:
       run: |
         mkdir imagine-sdk
         mkdir EX-Emulators
-        wget "https://dl.google.com/android/repository/android-ndk-r26b-linux.zip"
-        unzip android-ndk-r26b-linux.zip
-        echo "ANDROID_NDK_PATH=${{ github.workspace }}/android-ndk-r26b" >> $GITHUB_ENV
+        wget "https://dl.google.com/android/repository/android-ndk-r26c-linux.zip"
+        unzip android-ndk-r26c-linux.zip
+        echo "ANDROID_NDK_PATH=${{ github.workspace }}/android-ndk-r26c" >> $GITHUB_ENV
         echo "EMUFRAMEWORK_PATH=${{ github.workspace }}/EmuFramework" >> $GITHUB_ENV
         echo "IMAGINE_PATH=${{ github.workspace }}/imagine" >> $GITHUB_ENV
         echo "IMAGINE_SDK_PATH=${{ github.workspace }}/imagine-sdk" >> $GITHUB_ENV


### PR DESCRIPTION
Upgrade the Android NDK from r26b to r26c, which is the latest LTS release as of 2024-02-17 per
https://developer.android.com/ndk/downloads.