### PR TITLE
Refactor GitHub Actions Workflow for Improved Efficiency and Parallelization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,179 +4,192 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build
+    name: Build base
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image: ["2600.emu", "C64.emu", "GBA.emu", "GBC.emu", "Lynx.emu", "MD.emu", "MSX.emu", "NEO.emu", "NES.emu", "NGP.emu", "PCE.emu", "Snes9x", "Snes9x-1.43-9", "Snes9x-1.43-15", "Swan.emu", "Saturn.emu"]
-
     steps:
     - name: Checkout emu-ex-plus-alpha repo
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
     - name: Decode debug keystore
       env:
         DEBUG_KEYSTORE: ${{ secrets.DEBUG_KEYSTORE }}
       run: |
         if [ -z "$DEBUG_KEYSTORE" ]
         then
-          echo "No debug keystore value"
+          echo 'No debug keystore value'
         else
-          echo $DEBUG_KEYSTORE > debug.keystore.base64
-          base64 --decode debug.keystore.base64 > debug.keystore
-          sudo cp -f debug.keystore /root/.android/.
+          echo "$DEBUG_KEYSTORE" | base64 --decode > .debug.keystore
+          sudo mv -f .debug.keystore /root/.android/debug.keystore
         fi
-
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends autoconf automake autopoint bash binutils-arm-linux-gnueabi clang cmake file gawk gettext git libtool libtool-bin llvm make nasm pkg-config unzip wget
-
+        sudo apt-get install -y --no-install-recommends autoconf automake autopoint bash binutils-arm-linux-gnueabi cmake file gawk gettext git libtool libtool-bin make nasm pkg-config unzip wget
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'
-
     - name: Set up environment
       run: |
         mkdir imagine-sdk
-        mkdir EX-Emulators
-        wget "https://dl.google.com/android/repository/android-ndk-r27-beta2-linux.zip"
-        unzip android-ndk-r27-beta2-linux.zip
-        echo "ANDROID_NDK_PATH=${{ github.workspace }}/android-ndk-r27-beta2" >> $GITHUB_ENV
-        echo "EMUFRAMEWORK_PATH=${{ github.workspace }}/EmuFramework" >> $GITHUB_ENV
-        echo "IMAGINE_PATH=${{ github.workspace }}/imagine" >> $GITHUB_ENV
-        echo "IMAGINE_SDK_PATH=${{ github.workspace }}/imagine-sdk" >> $GITHUB_ENV
-        echo "COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
-
+        NDK_VERSION='r27c'
+        wget "https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip"
+        unzip android-ndk-${NDK_VERSION}-linux.zip
+        rm android-ndk-${NDK_VERSION}-linux.zip
+        mv android-ndk-${NDK_VERSION} android-ndk
+        GITHUB_ENV_FILE=env.github
+        echo "ANDROID_NDK_PATH=${{ github.workspace }}/android-ndk" >> "$GITHUB_ENV_FILE"
+        echo "EMUFRAMEWORK_PATH=${{ github.workspace }}/EmuFramework" >> "$GITHUB_ENV_FILE"
+        echo "IMAGINE_PATH=${{ github.workspace }}/imagine" >> "$GITHUB_ENV_FILE"
+        echo "IMAGINE_SDK_PATH=${{ github.workspace }}/imagine-sdk" >> "$GITHUB_ENV_FILE"
+        echo "COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)" >> "$GITHUB_ENV_FILE"
+        cat "$GITHUB_ENV_FILE" >> $GITHUB_ENV
     - name: Run script
+      working-directory: imagine/bundle/all
       run: |
-        cd imagine/bundle/all
         chmod +x ./makeAll-android.sh
         ./makeAll-android.sh install
       shell: bash
-
     - name: Build environment
       run: |
         make -f $IMAGINE_PATH/android-release.mk install V=1 -j`nproc`
         make -f $EMUFRAMEWORK_PATH/android-release.mk config -j`nproc`
         make -f $EMUFRAMEWORK_PATH/android-release.mk install V=1 -j`nproc`
+    - name: Keep cache small
+      run: rm -rf .git
+    - name: Save cache
+      uses: actions/cache/save@v4
+      with:
+        path: ./
+        key: ${{ github.sha }}-base
 
+  build_images:
+    name: Build images
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["2600.emu", "C64.emu", "GBA.emu", "GBC.emu", "Lynx.emu", "MD.emu", "MSX.emu", "NEO.emu", "NES.emu", "NGP.emu", "PCE.emu", "Snes9x", "Snes9x-1.43-9", "Snes9x-1.43-15", "Swan.emu", "Saturn.emu"]
+    steps:
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends autoconf automake autopoint bash binutils-arm-linux-gnueabi cmake file gawk gettext git libtool libtool-bin make nasm pkg-config
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ./
+        key: ${{ github.sha }}-base
+        fail-on-cache-miss: true
+    - name: Set up environment
+      run: |
+        GITHUB_ENV_FILE=env.github
+        cat "$GITHUB_ENV_FILE" >> $GITHUB_ENV
+    - name: Create EX-Emulators directory
+      run: mkdir EX-Emulators
     - name: Build 2600.emu
       if: ${{ matrix.image == '2600.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd 2600.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/2600Emu-release.apk "../EX-Emulators/2600Emu-${COMMIT_PREFIX}.apk"
-
     - name: Build C64.emu
       if: ${{ matrix.image == 'C64.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd C64.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/C64Emu-release.apk "../EX-Emulators/C64Emu-${COMMIT_PREFIX}.apk"
-
     - name: Build GBA.emu
       if: ${{ matrix.image == 'GBA.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd GBA.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/GbaEmu-release.apk "../EX-Emulators/GbaEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build GBC.emu
       if: ${{ matrix.image == 'GBC.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd GBC.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/GbcEmu-release.apk "../EX-Emulators/GbcEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build Lynx.emu
       if: ${{ matrix.image == 'Lynx.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd Lynx.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/LynxEmu-release.apk "../EX-Emulators/LynxEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build MD.emu
       if: ${{ matrix.image == 'MD.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd MD.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/MdEmu-release.apk "../EX-Emulators/MdEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build MSX.emu
       if: ${{ matrix.image == 'MSX.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd MSX.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/MsxEmu-release.apk "../EX-Emulators/MsxEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build NEO.emu
       if: ${{ matrix.image == 'NEO.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd NEO.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/NeoEmu-release.apk "../EX-Emulators/NeoEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build NES.emu
       if: ${{ matrix.image == 'NES.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd NES.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/NesEmu-release.apk "../EX-Emulators/NesEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build NGP.emu
       if: ${{ matrix.image == 'NGP.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd NGP.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/NgpEmu-release.apk "../EX-Emulators/NgpEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build PCE.emu
       if: ${{ matrix.image == 'PCE.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd PCE.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/PceEmu-release.apk "../EX-Emulators/PceEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build Snes9x
       if: ${{ matrix.image == 'Snes9x' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd Snes9x
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/Snes9xEXPlus-release.apk "../EX-Emulators/Snes9xEXPlus-${COMMIT_PREFIX}.apk"
-
     - name: Build Snes9x-1.43-9
       if: ${{ matrix.image == 'Snes9x-1.43-9' }}
+      working-directory: Snes9x/1.43
       run: |
-        cd Snes9x/1.43
         make -f android-release-9.mk android-apk V=1 -j`nproc`
         cp target/android-release-9/build/outputs/apk/release/Snes9xEX-release.apk "../../EX-Emulators/Snes9xEX-9-${COMMIT_PREFIX}.apk"
-
     - name: Build Snes9x-1.43-15
       if: ${{ matrix.image == 'Snes9x-1.43-15' }}
+      working-directory: Snes9x/1.43
       run: |
-        cd Snes9x/1.43
         make -f android-release-15.mk android-apk V=1 -j`nproc`
         cp target/android-release-15/build/outputs/apk/release/Snes9xEX-release.apk "../../EX-Emulators/Snes9xEX-15-${COMMIT_PREFIX}.apk"
-
     - name: Build Swan.emu
       if: ${{ matrix.image == 'Swan.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd Swan.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/SwanEmu-release.apk "../EX-Emulators/SwanEmu-${COMMIT_PREFIX}.apk"
-
     - name: Build Saturn.emu
       if: ${{ matrix.image == 'Saturn.emu' }}
+      working-directory: ${{ matrix.image }}
       run: |
-        cd Saturn.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
         cp target/android-release/build/outputs/apk/release/SaturnEmu-release.apk "../EX-Emulators/SaturnEmu-${COMMIT_PREFIX}.apk"
-
     - name: Upload EX-Emulators artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -186,25 +199,22 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, build_images]
     if: github.ref == 'refs/heads/master'
-
     steps:
     - name: Checkout emu-ex-plus-alpha repo
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
     - name: Download Artifacts
       uses: actions/download-artifact@v4
       with:
         path: EX-Emulators
         merge-multiple: true
-
     - name: Re-ZIP artifacts
+      working-directory: EX-Emulators
       run: |
-        mkdir dist
-        cd EX-Emulators
+        mkdir ../dist
         COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)
         for artifact in *.apk
         do
@@ -213,14 +223,13 @@ jobs:
           zip "../dist/${file_name//-${COMMIT_PREFIX}/}.zip" "${file_name}.apk"
         done
         zip -r "../dist/EX-Emulators.zip" *.apk
-
     - name: Update Git Tag
       run: |
         git tag -f Pre-release
         git push -f origin Pre-release
-
     - name: Create Release
-      uses: ncipollo/release-action@v1
+      # v1.16.0
+      uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174
       with:
         prerelease: true
         allowUpdates: true


### PR DESCRIPTION
This change enhances the GitHub Actions workflow by consolidating common steps into a single job and parallelizing the emulator build steps using a matrix strategy.

Major Changes Made:
* Common Steps Consolidated: Merged setup and installation steps into one job (build) to avoid redundancy.
* Parallel Builds: Introduced a new job (build_images) that runs concurrently for each emulator, improving build times and resource utilization.
* Conditional Logic: Simplified the emulator build process with conditional statements to handle specific emulator requirements efficiently.

Minor Changes Made:
* Update Android NDK to r27c
* Pin ncipollo/release-action GitHub Actions workflow to latest release using commit hash

This refactor aims to streamline the workflow, reduce execution time, and maintain clarity in the CI/CD process.